### PR TITLE
Corrected reference for 1password

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ recommend using Nix to install Zen.
 Zen has to be manually added to the list of browsers that 1Password will
 communicate with. See [this wiki article](https://nixos.wiki/wiki/1Password)
 for more information. To enable 1Password integration, you need to add the line
-`.zen-wrapped` to the file `/etc/1password/custom_allowed_browsers`.
+`zen` to the file `/etc/1password/custom_allowed_browsers`.
 
 ## License
 


### PR DESCRIPTION
Since the main binary is not being picked up as `.zen-wrapped` by 1Password anymore, but rather just `zen`.

Tested on my personal configuration.