### PR TITLE
fix: add applictionName

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
+        "lastModified": 1740560979,
+        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
         "type": "github"
       },
       "original": {

--- a/zen-browser-unwrapped.nix
+++ b/zen-browser-unwrapped.nix
@@ -30,6 +30,7 @@ in
 stdenv.mkDerivation (finalAttrs: {
   inherit version;
   pname = "zen-browser-unwrapped";
+  applicationName = "Zen Browser";
 
   src = fetchurl {
     inherit url hash;


### PR DESCRIPTION
Zen browser will not build without this, due to changes upstream.

See: https://github.com/NixOS/nixpkgs/commit/e04cba723699d9090b436d84d35d0983b0b01565
