### PR TITLE
Simplify flakeless install

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ environment.systemPackages = [
 ];
 ```
 
+If you don't want to use flakes, you can add it like:
+
+```nix
+environment.systemPackages = 
+  let
+    zen-browser = import (builtins.fetchTarball "https://github.com/youwen5/zen-browser-flake/archive/master.tar.gz") {
+      inherit pkgs;
+    };
+  in
+  [
+    zen-browser    
+  ];
+```
+
 A binary called `zen` is provided as well as a desktop file that should show up
 in app launchers.
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+{ pkgs, system ? pkgs.system, ... }:
+let
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
+in
+rec {
+  zen-browser-unwrapped = pkgs.callPackage ./zen-browser-unwrapped.nix {
+    inherit (sources.${system}) hash url;
+    inherit (sources) version;
+  };
+  zen-browser = pkgs.callPackage ./zen-browser.nix { inherit zen-browser-unwrapped; };
+  zen-browser-generic = builtins.trace "WARNING: Zen upstream no longer differentiates between specific and generic builds, this package is kept for flake backwards-compatibility only. Please use the default `zen-browser` package instead." zen-browser;
+  default = zen-browser;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,17 +22,9 @@
         system:
         let
           pkgs = import nixpkgs { inherit system; };
-          sources = builtins.fromJSON (builtins.readFile ./sources.json);
+          packages = import ./. { inherit pkgs system; };
         in
-        rec {
-          zen-browser-unwrapped = pkgs.callPackage ./zen-browser-unwrapped.nix {
-            inherit (sources.${system}) hash url;
-            inherit (sources) version;
-          };
-          zen-browser = pkgs.callPackage ./zen-browser.nix { inherit zen-browser-unwrapped; };
-          zen-browser-generic = builtins.trace "WARNING: Zen upstream no longer differentiates between specific and generic builds, this package is kept for flake backwards-compatibility only. Please use the default `zen-browser` package instead." zen-browser;
-          default = zen-browser;
-        }
+        packages
       );
 
       apps = forAllSystems (


### PR DESCRIPTION
This PR moves the package instantiation into a `default.nix` in order to be able to use this project outside of a flake by pinning it.