### PR TITLE
Add RFC169-style option names

### DIFF
--- a/zen-browser-unwrapped.nix
+++ b/zen-browser-unwrapped.nix
@@ -85,7 +85,14 @@ stdenv.mkDerivation (finalAttrs: {
 
     libName = "zen-${version}";
     binaryName = finalAttrs.meta.mainProgram;
+
+    # Nixpkgs uses RFC169 terminology.
+    #
+    #  https://github.com/NixOS/nixpkgs/commit/cf6a014d171b2eccc2efc2587ac526ea1051858d
+    #
     gssSupport = true;
     ffmpegSupport = true;
+    withFFmpeg = true;
+    withGSSAPI = true;
   };
 })


### PR DESCRIPTION
Upstream nixpkgs has changed the attribute names required to get FFmpeg and GSSAPI support in Zen.

Let's just define both the old and the new options to support both the latest stable and the new unstable Nixpkgs.

https://github.com/NixOS/nixpkgs/commit/cf6a014d171b2eccc2efc2587ac526ea1051858d